### PR TITLE
feat: support Github login with 2FA using TOTP code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To run Tokenator, the following environment variables need to be set:
 - `TOKENATOR_LP_AUTH` - Launchpad Remote Build auth file contents
 - `TOKENATOR_SNAPCRAFTERS_BOT_LOGIN` - Github login for the "snapcrafters-bot" user
 - `TOKENATOR_SNAPCRAFTERS_BOT_PASSWORD` - Github password for the "snapcrafters-bot" user
+- `TOKENATOR_SNAPCRAFTERS_TOTP_SECRET` - Github TOTP secret for the "snapcrafters-bot" user
 - `TOKENATOR_APP_ID` - ID of the Github app
 - `TOKENATOR_APP_SECRET` - Client secret for the Github app
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v58 v58.0.0
+	github.com/pquerna/otp v1.4.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/tidwall/gjson v1.17.0
@@ -17,6 +18,7 @@ require (
 
 require (
 	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.8.1 h1:uQxhNlArOIdbrH1tr0UXwdVFgDcZDrZVdcpygAc
 github.com/PuerkitoBio/goquery v1.8.1/go.mod h1:Q8ICL1kNUJ2sXGoAhPGUdYDJvgQgHzJsnnd3H7Ho5jQ=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,6 +42,8 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
+github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,8 +45,9 @@ type Credentials struct {
 
 // LoginCredentials represents traditional username/password credentials
 type LoginCredentials struct {
-	Login    string
-	Password string
+	Login      string
+	Password   string
+	TOTPSecret string
 }
 
 // GithubAppCredentials enable the representation of a Github App ID and client secret

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ The following environment variables must be set:
 	- TOKENATOR_LP_AUTH - Launchpad Remote Build auth file contents
 	- TOKENATOR_SNAPCRAFTERS_BOT_LOGIN - Github login for the "snapcrafters-bot" user
 	- TOKENATOR_SNAPCRAFTERS_BOT_PASSWORD - Github password for the "snapcrafters-bot" user
+	- TOKENATOR_SNAPCRAFTERS_BOT_TOTP_SECRET - Github TOTP secret for "snapcrafters-bot" user
 	- TOKENATOR_APP_ID  - ID of the Github app
 	- TOKENATOR_APP_SECRET - Client secret for the Github app
 
@@ -115,6 +116,7 @@ func parseCreds() (config.Credentials, error) {
 		"snapcrafters_org_pat",
 		"snapcrafters_bot_login",
 		"snapcrafters_bot_password",
+		"snapcrafters_bot_totp_secret",
 		"app_id",
 		"app_secret",
 		"lp_auth",
@@ -132,8 +134,9 @@ func parseCreds() (config.Credentials, error) {
 			Password: viper.GetString("snapcraft_password"),
 		},
 		Bot: config.LoginCredentials{
-			Login:    viper.GetString("snapcrafters_bot_login"),
-			Password: viper.GetString("snapcrafters_bot_password"),
+			Login:      viper.GetString("snapcrafters_bot_login"),
+			Password:   viper.GetString("snapcrafters_bot_password"),
+			TOTPSecret: viper.GetString("snapcrafters_bot_totp_secret"),
 		},
 		GithubApp: config.GithubAppCredentials{
 			ID:     viper.GetInt("app_id"),


### PR DESCRIPTION
Github now mandates 2FA, which means the simple username/password combination we were using is no longer able to authenticate with Github.

This is a relatively simple change that enables `tokenator` to take the TOTP secret as part of it's environment, and use that to generate TOTP codes when required. These are POST'ed, along with the authenticity token from the rendered form to `github.com/sessions/two-factor/app`, which validates the session.

This PR also abstracts away the `checkLoggedIn` method.

Tested locally:

```
❯ op run --env-file snapcrafters.env -- go run main.go -v -r terraform
time=2024-04-19T17:10:54.285+01:00 level=INFO msg="secret set" repo=snapcrafters/terraform secret_name=SNAP_STORE_CANDIDATE environment="Candidate Branch"
time=2024-04-19T17:10:56.096+01:00 level=INFO msg="secret set" repo=snapcrafters/terraform secret_name=SNAP_STORE_STABLE environment="Candidate Branch"
time=2024-04-19T17:10:57.098+01:00 level=INFO msg="secret set" repo=snapcrafters/terraform secret_name=LP_BUILD_SECRET environment="Candidate Branch"
time=2024-04-19T17:10:59.074+01:00 level=DEBUG msg="created personal access token" token_name=token8r-9ec4-terraform-latest token_id=deadbeef
time=2024-04-19T17:11:01.122+01:00 level=INFO msg="secret set" repo=snapcrafters/terraform secret_name=SNAPCRAFTERS_BOT_COMMIT environment="Candidate Branch"
time=2024-04-19T17:11:02.113+01:00 level=DEBUG msg="deleted personal access token" token_name=token8r-bff3-terraform-latest token_id=deadbeef
```