### PR TITLE
feat: ensure 'testing' label exists on repos during setup

### DIFF
--- a/internal/gh/repo_client.go
+++ b/internal/gh/repo_client.go
@@ -133,6 +133,32 @@ func (rc *RepoClient) createEnvironment(ctx context.Context, repo string, track 
 	return nil
 }
 
+// EnsureLabel checks whether a label with the given name exists on the specified
+// repository and creates it if it does not. The color should be a 6-digit hex
+// string without the leading '#' (e.g. "0075ca").
+func (rc *RepoClient) EnsureLabel(ctx context.Context, repo, name, color, description string) error {
+	_, resp, err := rc.client.Issues.GetLabel(ctx, rc.org, repo, name)
+	if err == nil {
+		// Label already exists.
+		return nil
+	}
+
+	if resp == nil || resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("failed to check for label %q: %w", name, err)
+	}
+
+	_, _, err = rc.client.Issues.CreateLabel(ctx, rc.org, repo, &github.Label{
+		Name:        &name,
+		Color:       &color,
+		Description: &description,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create label %q: %w", name, err)
+	}
+
+	return nil
+}
+
 func (rc *RepoClient) createDeploymentBranchPolicy(ctx context.Context, repo string, env string, branch string) error {
 	b := branch
 	branchPolicyRequest := &github.DeploymentBranchPolicyRequest{Name: &b}

--- a/internal/tokenator/manager.go
+++ b/internal/tokenator/manager.go
@@ -106,6 +106,16 @@ func (m *Manager) Process(filter []string) error {
 			snaps = []string{repo.Name}
 		}
 
+		// Ensure the "testing" label exists so the Call for Testing workflow
+		// can tag issues correctly.
+		err = m.repoClient.EnsureLabel(ctx, repo.Name, "testing", "0075ca", "Used by the Call for Testing workflow")
+		if err != nil {
+			return fmt.Errorf("failed to ensure 'testing' label on %s: %w", repo.Name, err)
+		}
+
+		fullName := fmt.Sprintf("%s/%s", m.config.Org, repo.Name)
+		slog.Info("label ensured", "repo", fullName, "label", "testing")
+
 		for _, track := range repo.Tracks {
 			// Generate the candidate store token and set it on Github
 			err := m.setStoreSecret(ctx, repo.Name, snaps, track, "candidate")


### PR DESCRIPTION
## Problem

The Call for Testing CI stage applies a `testing` label to issues. On newly onboarded repositories this label doesn't exist yet, causing the workflow to fail.

## Solution

Add an `EnsureLabel` method to `RepoClient` that checks for a label by name on the target repository and creates it if absent. Call it once per repo in `Manager.Process` before iterating over tracks, alongside the existing environment/secret setup.

The label is created with:
- **Name:** `testing`
- **Colour:** `#0075ca` (GitHub's default "documentation" blue)
- **Description:** `Used by the Call for Testing workflow`

If the label already exists the check is a no-op, so this is safe to run against repos that have already been onboarded.